### PR TITLE
ArgumentOutOfRangeException fix

### DIFF
--- a/Plugins/BezierSolution/BezierSpline.cs
+++ b/Plugins/BezierSolution/BezierSpline.cs
@@ -618,8 +618,6 @@ namespace BezierSolution
 			}
 			else
 			{
-				// 2nd conditions isn't 'else if' because in rare occasions, floating point precision issues may arise; e.g. for normalizedT = -0.0000000149,
-				// incrementing the value by 1 results in perfect 1.0000000000 with no mantissa
 				while ( normalizedT < 0f )
 					normalizedT += 1f;
 				while ( normalizedT >= 1f )
@@ -700,9 +698,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				if( normalizedT < 0f )
+				while ( normalizedT < 0f )
 					normalizedT += 1f;
-				if( normalizedT >= 1f )
+				while ( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -756,9 +754,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				if( normalizedT < 0f )
+				while ( normalizedT < 0f )
 					normalizedT += 1f;
-				if( normalizedT >= 1f )
+				while ( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -815,9 +813,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				if( normalizedT < 0f )
+				while ( normalizedT < 0f )
 					normalizedT += 1f;
-				if( normalizedT >= 1f )
+				while ( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 

--- a/Plugins/BezierSolution/BezierSpline.cs
+++ b/Plugins/BezierSolution/BezierSpline.cs
@@ -618,9 +618,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				while ( normalizedT < 0f )
+				while( normalizedT < 0f )
 					normalizedT += 1f;
-				while ( normalizedT >= 1f )
+				while( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -660,9 +660,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				while ( normalizedT < 0f )
+				while( normalizedT < 0f )
 					normalizedT += 1f;
-				while ( normalizedT >= 1f )
+				while( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -698,9 +698,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				while ( normalizedT < 0f )
+				while( normalizedT < 0f )
 					normalizedT += 1f;
-				while ( normalizedT >= 1f )
+				while( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -754,9 +754,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				while ( normalizedT < 0f )
+				while( normalizedT < 0f )
 					normalizedT += 1f;
-				while ( normalizedT >= 1f )
+				while( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -813,9 +813,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				while ( normalizedT < 0f )
+				while( normalizedT < 0f )
 					normalizedT += 1f;
-				while ( normalizedT >= 1f )
+				while( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 

--- a/Plugins/BezierSolution/BezierSpline.cs
+++ b/Plugins/BezierSolution/BezierSpline.cs
@@ -620,9 +620,9 @@ namespace BezierSolution
 			{
 				// 2nd conditions isn't 'else if' because in rare occasions, floating point precision issues may arise; e.g. for normalizedT = -0.0000000149,
 				// incrementing the value by 1 results in perfect 1.0000000000 with no mantissa
-				if( normalizedT < 0f )
+				while ( normalizedT < 0f )
 					normalizedT += 1f;
-				if( normalizedT >= 1f )
+				while ( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 
@@ -662,9 +662,9 @@ namespace BezierSolution
 			}
 			else
 			{
-				if( normalizedT < 0f )
+				while ( normalizedT < 0f )
 					normalizedT += 1f;
-				if( normalizedT >= 1f )
+				while ( normalizedT >= 1f )
 					normalizedT -= 1f;
 			}
 

--- a/Plugins/BezierSolution/Other/BezierDataStructures.cs
+++ b/Plugins/BezierSolution/Other/BezierDataStructures.cs
@@ -169,9 +169,9 @@ namespace BezierSolution
 				}
 				else
 				{
-					while ( normalizedT < 0f )
+					while( normalizedT < 0f )
 						normalizedT += 1f;
-					while ( normalizedT >= 1f )
+					while( normalizedT >= 1f )
 						normalizedT -= 1f;
 				}
 
@@ -228,9 +228,9 @@ namespace BezierSolution
 				}
 				else
 				{
-					while ( percentage < 0f )
+					while( percentage < 0f )
 						percentage += 1f;
-					while ( percentage >= 1f )
+					while( percentage >= 1f )
 						percentage -= 1f;
 				}
 
@@ -256,9 +256,9 @@ namespace BezierSolution
 				}
 				else
 				{
-					while ( percentage < 0f )
+					while( percentage < 0f )
 						percentage += 1f;
-					while ( percentage >= 1f )
+					while( percentage >= 1f )
 						percentage -= 1f;
 				}
 

--- a/Plugins/BezierSolution/Other/BezierDataStructures.cs
+++ b/Plugins/BezierSolution/Other/BezierDataStructures.cs
@@ -169,9 +169,9 @@ namespace BezierSolution
 				}
 				else
 				{
-					if( normalizedT < 0f )
+					while ( normalizedT < 0f )
 						normalizedT += 1f;
-					if( normalizedT >= 1f )
+					while ( normalizedT >= 1f )
 						normalizedT -= 1f;
 				}
 
@@ -228,9 +228,9 @@ namespace BezierSolution
 				}
 				else
 				{
-					if( percentage < 0f )
+					while ( percentage < 0f )
 						percentage += 1f;
-					if( percentage >= 1f )
+					while ( percentage >= 1f )
 						percentage -= 1f;
 				}
 
@@ -256,9 +256,9 @@ namespace BezierSolution
 				}
 				else
 				{
-					if( percentage < 0f )
+					while ( percentage < 0f )
 						percentage += 1f;
-					if( percentage >= 1f )
+					while ( percentage >= 1f )
 						percentage -= 1f;
 				}
 


### PR DESCRIPTION
A fix for a problem I ran into while testing high speed tank tracks.

The problem:
If `normalizedT` is equal or over 2 current correction will make it at most 1. This will cause
`float t = normalizedT * ( m_loop ? endPoints.Count : ( endPoints.Count - 1 ) );`
(...)
`int startIndex = (int) t;`
to make startIndex equal to or more than `endPoints.Count` and will cause `ArgumentOutOfRangeException` here:
`
startPoint = endPoints[startIndex];
`

Fix fixes that.